### PR TITLE
Don't define snprintf for Visual Studio 2015.

### DIFF
--- a/src/lzo_supp.h
+++ b/src/lzo_supp.h
@@ -471,7 +471,7 @@
 #    ifndef vsnprintf
 #    define vsnprintf _vsnprintf
 #    endif
-#  else
+#  elif (_MSC_VER < 1900)
 #    ifndef snprintf
 #    define snprintf _snprintf
 #    endif


### PR DESCRIPTION
Visual Studio 2015 adds support for snprintf, so no need for that macro.
